### PR TITLE
Fix : ArrayList -> TreeMap

### DIFF
--- a/DataStructure/README.md
+++ b/DataStructure/README.md
@@ -180,7 +180,7 @@ _RBT 는 BST 의 삽입, 삭제 연산 과정에서 발생할 수 있는 문제�
 
 삭제도 삽입과 마찬가지로 BST 의 특성을 유지하면서 해당 노드를 삭제한다. 삭제될 노드의 child 의 개수에 따라 rotation 방법이 달라지게 된다. 그리고 만약 지워진 노드의 색깔이 Black 이라면 Black-Height 가 1 감소한 경로에 black node 가 1 개 추가되도록 rotation 하고 노드의 색깔을 조정한다. 지워진 노드의 색깔이 red 라면 Violation 이 발생하지 않으므로 RBT 가 그대로 유지된다.
 
-Java Collection 에서 ArrayList 도 내부적으로 RBT 로 이루어져 있고, HashMap 에서의 `Separate Chaining`에서도 사용된다. 그만큼 효율이 좋고 중요한 자료구조이다.
+Java Collection 에서 TreeMap 도 내부적으로 RBT 로 이루어져 있고, HashMap 에서의 `Separate Chaining`에서도 사용된다. 그만큼 효율이 좋고 중요한 자료구조이다.
 
 [뒤로](https://github.com/JaeYeopHan/for_beginner)/[위로](#part-1-2-datastructure)
 


### PR DESCRIPTION
### This Pull Request is...
* [ ] Edit typos or links
* [x] Inaccurate information
* [ ] New Resources

#### Description
openJDK 17기준 실제 java.util.ArrayList 코드를 살펴보면 RBT 구조를 사용하고 있지 않습니다.
단지 Array를 베이스로 Resizable Array Interface를 구현하고 있을 뿐입니다.
RBT를 사용하는대표적인 Collection은 TreeMap이 있는데 이 클래스로 대체하면 좋을 것 같습니다.


Reference :
1. ArrayList, https://github.com/openjdk/jdk17/blob/master/src/java.base/share/classes/java/util/ArrayList.java
2. TreeMap, https://github.com/openjdk/jdk17/blob/master/src/java.base/share/classes/java/util/TreeMap.java
