### PR TITLE
fix: 알고리즘 틀린 설명 수정 및 예시 코드 변경

### DIFF
--- a/Algorithm/README.md
+++ b/Algorithm/README.md
@@ -337,7 +337,36 @@ Count Sort 는 말 그대로 몇 개인지 개수를 세어 정렬하는 방식�
 
 ## Prime Number Algorithm
 
-소수란 양의 약수를 딱 두 개만 갖는 자연수를 소수라 부른다. 2, 3, 5, 7, 11, …이 그런 수들인데, 소수를 판별하는 방법으로 첫 번째로 임의의 양의 정수 N 이 소수인지 판별하기 위해서는 N 을 2 부터 N 보다 1 작은 수까지 나누어서 나머지가 0 인 경우가 있는지 검사하는 방법과 두 번째로 `에라토스테네스의 체`를 사용할 수 있다.
+소수란 양의 약수를 딱 두 개만 갖는 자연수를 소수라 부른다. 2, 3, 5, 7, 11, …이 그런 수들인데, 소수를 판별하는 방법으로 첫 번째로 3보다 크거나 같은 임의의 양의 정수 N이 소수인지 판별하기 위해서는 N 을 2 부터 N 보다 1 작은 수까지 나누어서 나머지가 0 인 경우가 있는지 검사하는 방법과 두 번째로 `에라토스테네스의 체`를 사용할 수 있다.  
+
+아래 코드는 2부터 N - 1까지를 순회하며 소수인지 판별하는 코드와 2부터 √N까지 순회하며 소수인지 판별하는 코드이다.
+```cpp
+// Time complexity: O(N)
+bool is_prime(int N) {
+    if(N == 1) return false;
+    for(int i = 2; i < N - 1; ++i) {
+        if(N % i == 0) {
+            return false;
+        }
+    }
+    return true;
+}
+```
+
+```cpp
+// Time complexity: O(√N)
+bool is_prime(int N) {
+    if(N == 1) return false;
+    for(long long i = 2; i * i <= N; ++i) { // 주의) i를 int로 선언하면 i*i를 계산할 때 overflow가 발생할 수 있다.
+        if(N % i == 0) {
+            return false;
+        }
+    }
+    return true;
+}
+```
+
+
 
 ### 에라토스테네스의 체 [Eratosthenes’ sieve]
 

--- a/Algorithm/README.md
+++ b/Algorithm/README.md
@@ -337,7 +337,7 @@ Count Sort 는 말 그대로 몇 개인지 개수를 세어 정렬하는 방식�
 
 ## Prime Number Algorithm
 
-소수란 양의 약수를 딱 두 개만 갖는 자연수를 소수라 부른다. 2, 3, 5, 7, 11, …이 그런 수들인데, 소수를 판별하는 방법으로 첫번째 어떤 수 N 이 소수인지 판별하기 위해서는 N 을 2 부터 N 보다 1 작은 수까지 나누어서 나머지가 0 인 경우가 있는지 검사하는 방법과 두번째로 `에라토스테네스의 체`를 사용할 수 있다.
+소수란 양의 약수를 딱 두 개만 갖는 자연수를 소수라 부른다. 2, 3, 5, 7, 11, …이 그런 수들인데, 소수를 판별하는 방법으로 첫 번째로 임의의 양의 정수 N 이 소수인지 판별하기 위해서는 N 을 2 부터 N 보다 1 작은 수까지 나누어서 나머지가 0 인 경우가 있는지 검사하는 방법과 두 번째로 `에라토스테네스의 체`를 사용할 수 있다.
 
 ### 에라토스테네스의 체 [Eratosthenes’ sieve]
 
@@ -401,9 +401,9 @@ Count Sort 는 말 그대로 몇 개인지 개수를 세어 정렬하는 방식�
 
 | Space Complexity | Time Complexity |
 | :--------------: | :-------------: |
-|       O(n)       |   O(loglogn)    |
+|       O(n)       |   O(nloglogn)   |
 
-#### [code](https://github.com/alstn2468/BaekJoon_Online_Judge/blob/master/1900~1999/1929.c)
+#### [code](http://boj.kr/90930351636e46f7842b1f017eec831b)
 
 [뒤로](https://github.com/JaeYeopHan/for_beginner)/[위로](#algorithm)
 


### PR DESCRIPTION
### This Pull Request is...
* [x] Edit typos or links
* [x] Inaccurate information
* [ ] New Resources

#### Description
- 에라토스테네스 체의 시간복잡도는 $O(N\log \log N)$으로 기존에 $O(\log \log N)$으로 되어 있었습니다. 잘못된 시간복잡도 설명을 수정하였습니다.
- 사소한 수정을 하였습니다. (어떤 수 N => 임의의 양의 정수 N)
- 에라토스테네스 체 설명 밑에 있던 code의 시간복잡도는 $O(N\log N)$입니다. (이는 밑에 수식으로 부가설명합니다.) 또한, 에라토스테네스의 체와 같아보이지만 엄밀히 따지자면 살짝 다릅니다. 따라서, 에라토스테네스의 체 방식으로 작성한 코드 링크로 대체하였습니다.

#### 예시로 첨부된 코드의 시간복잡도가 $O(N\log N)$인 이유
연산횟수는 $\displaystyle \sum_{i=2}^{N} {\frac{N}{i}}$로 표현할 수 있습니다.  
$\displaystyle \sum_{i=2}^{N} {\frac{N}{i}} \le \int_{2}^{N} \frac{N}{x} dx ≈ N\ln N$  
시간복잡도에서는 $O(N \ln N)$와 $O(N \log N)$을 크게 구분하지 않기 때문에 최종 시간복잡도는 $O(N\log N)$로 볼 수 있습니다.
